### PR TITLE
Format code with `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,8 @@ repos:
     rev: v0.9.3
     hooks:
       - id: ruff
-        types: [file]
-        types_or: [python, pyi, toml]
         args: ["--show-fixes"]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/check.sh
+++ b/check.sh
@@ -12,6 +12,18 @@ if [ -z "${GITHUB_STEP_SUMMARY+x}" ]; then
     ON_GITHUB_CI=false
 fi
 
+# Autoformatter *first*, to avoid double-reporting errors
+echo "::group::Ruff format"
+if ! ruff format --check; then
+    echo "* Ruff formatting found issues" >> "$GITHUB_STEP_SUMMARY"
+    EXIT_STATUS=1
+    ruff format --diff
+    echo "::endgroup::"
+    echo "::error:: Ruff formatting found issues"
+else
+    echo "::endgroup::"
+fi
+
 # Run ruff, configured in pyproject.toml
 echo "::group::Ruff"
 if ! ruff check .; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,9 @@ warn_unreachable = true
 combine-as-imports = true
 
 [tool.ruff]
-line-length = 79
+line-length = 119
 fix = true
+exclude = ["tools/mypy_annotate.py"]
 
 include = ["*.py", "*.pyi", "**/pyproject.toml"]
 

--- a/src/neuro_api_tony/api.py
+++ b/src/neuro_api_tony/api.py
@@ -79,24 +79,14 @@ class NeuroAPI:
         self.current_action_id: str | None = None
 
         # Dependency injection
+        # fmt: off
         self.on_startup: Callable[[StartupCommand], None] = lambda cmd: None
         self.on_context: Callable[[ContextCommand], None] = lambda cmd: None
-        self.on_actions_register: Callable[[ActionsRegisterCommand], None] = (
-            lambda cmd: None
-        )
-        self.on_actions_unregister: Callable[
-            [ActionsUnregisterCommand],
-            None,
-        ] = lambda cmd: None
-        self.on_actions_force: Callable[[ActionsForceCommand], None] = (
-            lambda cmd: None
-        )
-        self.on_action_result: Callable[[ActionResultCommand], None] = (
-            lambda cmd: None
-        )
-        self.on_shutdown_ready: Callable[[ShutdownReadyCommand], None] = (
-            lambda cmd: None
-        )
+        self.on_actions_register: Callable[[ActionsRegisterCommand], None] = lambda cmd: None
+        self.on_actions_unregister: Callable[[ActionsUnregisterCommand], None] = lambda cmd: None
+        self.on_actions_force: Callable[[ActionsForceCommand], None] = lambda cmd: None
+        self.on_action_result: Callable[[ActionResultCommand], None] = lambda cmd: None
+        self.on_shutdown_ready: Callable[[ShutdownReadyCommand], None] = lambda cmd: None
         self.on_unknown_command: Callable[[Any], None] = lambda cmd: None
         self.log_system: Callable[[str], None] = lambda message: None
         self.log_debug: Callable[[str], None] = lambda message: None
@@ -104,10 +94,9 @@ class NeuroAPI:
         self.log_warning: Callable[[str], None] = lambda message: None
         self.log_error: Callable[[str], None] = lambda message: None
         self.log_critical: Callable[[str], None] = lambda message: None
-        self.log_raw: Callable[[str, bool], None] = (
-            lambda message, incoming: None
-        )
+        self.log_raw: Callable[[str, bool], None] = lambda message, incoming: None
         self.get_delay: Callable[[], float] = lambda: 0.0
+        # fmt: on
 
         self.async_library_running = False
         self.async_library_root_cancel: trio.CancelScope

--- a/src/neuro_api_tony/api.py
+++ b/src/neuro_api_tony/api.py
@@ -31,7 +31,42 @@ from .model import NeuroAction
 ACTION_NAME_ALLOWED_CHARS: Final = "abcdefghijklmnopqrstuvwxyz0123456789_-"
 
 # See https://github.com/VedalAI/neuro-game-sdk/blob/main/API/SPECIFICATION.md#action
-INVALID_SCHEMA_KEYS: Final = frozenset({"$anchor", "$comment", "$defs", "$dynamicAnchor", "$dynamicRef", "$id", "$ref", "$schema", "$vocabulary", "additionalProperties", "allOf", "anyOf", "contentEncoding", "contentMediaType", "contentSchema", "dependentRequired", "dependentSchemas", "deprecated", "description", "else", "if", "maxProperties", "minProperties", "not", "oneOf", "patternProperties", "readOnly", "then", "title", "unevaluatedItems", "unevaluatedProperties", "writeOnly"})
+INVALID_SCHEMA_KEYS: Final = frozenset(
+    {
+        "$anchor",
+        "$comment",
+        "$defs",
+        "$dynamicAnchor",
+        "$dynamicRef",
+        "$id",
+        "$ref",
+        "$schema",
+        "$vocabulary",
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "contentEncoding",
+        "contentMediaType",
+        "contentSchema",
+        "dependentRequired",
+        "dependentSchemas",
+        "deprecated",
+        "description",
+        "else",
+        "if",
+        "maxProperties",
+        "minProperties",
+        "not",
+        "oneOf",
+        "patternProperties",
+        "readOnly",
+        "then",
+        "title",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "writeOnly",
+    },
+)
 
 
 class NeuroAPI:
@@ -46,11 +81,22 @@ class NeuroAPI:
         # Dependency injection
         self.on_startup: Callable[[StartupCommand], None] = lambda cmd: None
         self.on_context: Callable[[ContextCommand], None] = lambda cmd: None
-        self.on_actions_register: Callable[[ActionsRegisterCommand], None] = lambda cmd: None
-        self.on_actions_unregister: Callable[[ActionsUnregisterCommand], None] = lambda cmd: None
-        self.on_actions_force: Callable[[ActionsForceCommand], None] = lambda cmd: None
-        self.on_action_result: Callable[[ActionResultCommand], None] = lambda cmd: None
-        self.on_shutdown_ready: Callable[[ShutdownReadyCommand], None] = lambda cmd: None
+        self.on_actions_register: Callable[[ActionsRegisterCommand], None] = (
+            lambda cmd: None
+        )
+        self.on_actions_unregister: Callable[
+            [ActionsUnregisterCommand],
+            None,
+        ] = lambda cmd: None
+        self.on_actions_force: Callable[[ActionsForceCommand], None] = (
+            lambda cmd: None
+        )
+        self.on_action_result: Callable[[ActionResultCommand], None] = (
+            lambda cmd: None
+        )
+        self.on_shutdown_ready: Callable[[ShutdownReadyCommand], None] = (
+            lambda cmd: None
+        )
         self.on_unknown_command: Callable[[Any], None] = lambda cmd: None
         self.log_system: Callable[[str], None] = lambda message: None
         self.log_debug: Callable[[str], None] = lambda message: None
@@ -58,7 +104,9 @@ class NeuroAPI:
         self.log_warning: Callable[[str], None] = lambda message: None
         self.log_error: Callable[[str], None] = lambda message: None
         self.log_critical: Callable[[str], None] = lambda message: None
-        self.log_raw: Callable[[str, bool], None] = lambda message, incoming: None
+        self.log_raw: Callable[[str, bool], None] = (
+            lambda message, incoming: None
+        )
         self.get_delay: Callable[[], float] = lambda: 0.0
 
         self.async_library_running = False
@@ -69,17 +117,23 @@ class NeuroAPI:
         """Start hosting the websocket server with Trio in the background."""
         if self.received_loop_close_request:
             # Attempting to shut down
-            self.log_critical("Something attempted to start websocket server during shutdown, ignoring.")
+            self.log_critical(
+                "Something attempted to start websocket server during shutdown, ignoring.",
+            )
             return
 
         if self.async_library_running:
             # Already running, skip
-            self.log_critical("Something attempted to start websocket server a 2nd time, ignoring.")
+            self.log_critical(
+                "Something attempted to start websocket server a 2nd time, ignoring.",
+            )
             return
 
         def done_callback(run_outcome: Outcome[None]) -> None:
             """Handle when trio run completes."""
-            assert self.async_library_running, "How can stop running if not running?"
+            assert self.async_library_running, (
+                "How can stop running if not running?"
+            )
             self.async_library_running = False
             # Unwrap to make sure exceptions are printed
             run_outcome.unwrap()
@@ -148,19 +202,32 @@ class NeuroAPI:
     async def _run(self, address: str, port: int) -> None:
         """Server run root function."""
         self.log_system(f"Starting websocket server on ws://{address}:{port}.")
-        await serve_websocket(self._handle_websocket_request, address, port, ssl_context=None)
+        await serve_websocket(
+            self._handle_websocket_request,
+            address,
+            port,
+            ssl_context=None,
+        )
 
     @property
     def client_connected(self) -> bool:
         """Is there a client connected."""
         return self.message_send_channel is not None
 
-    async def _handle_websocket_request(self, request: WebSocketRequest) -> None:
+    async def _handle_websocket_request(
+        self,
+        request: WebSocketRequest,
+    ) -> None:
         """Handle websocket connection request."""
         if self.client_connected:
             # 503 is "service unavailable"
-            await request.reject(503, body=b"Server does not support multiple connections at once currently")
-            self.log_error("Another client attempted to connect, rejecting, server does not support multiple connections at once currently")
+            await request.reject(
+                503,
+                body=b"Server does not support multiple connections at once currently",
+            )
+            self.log_error(
+                "Another client attempted to connect, rejecting, server does not support multiple connections at once currently",
+            )
             return
 
         try:
@@ -168,11 +235,16 @@ class NeuroAPI:
             # Using message_send_channel to send websocket messages synchronously
             # Zero here means no buffer, send not allowed to happen if receive channel has
             # not read prior message waiting yet.
-            self.message_send_channel, receive_channel = trio.open_memory_channel[str](0)
-            with (self.message_send_channel, receive_channel):
+            self.message_send_channel, receive_channel = (
+                trio.open_memory_channel[str](0)
+            )
+            with self.message_send_channel, receive_channel:
                 # Accept connection
                 async with await request.accept() as connection:
-                    await self._handle_client_connection(connection, receive_channel)
+                    await self._handle_client_connection(
+                        connection,
+                        receive_channel,
+                    )
         finally:
             self.message_send_channel = None
 
@@ -185,8 +257,16 @@ class NeuroAPI:
         try:
             async with trio.open_nursery() as nursery:
                 # Start running connection read and write tasks in the background
-                nursery.start_soon(self._handle_consumer, websocket, nursery.cancel_scope)
-                nursery.start_soon(self._handle_producer, websocket, receive_channel)
+                nursery.start_soon(
+                    self._handle_consumer,
+                    websocket,
+                    nursery.cancel_scope,
+                )
+                nursery.start_soon(
+                    self._handle_producer,
+                    websocket,
+                    receive_channel,
+                )
         except trio.Cancelled:
             self.log_system("Closing current websocket connection.")
 
@@ -215,18 +295,28 @@ class NeuroAPI:
                     self.log_warning("Game name is not set.")
                 else:
                     # Check game name
-                    if json_cmd["command"] == "startup" or json_cmd["command"] == "game/startup":
+                    if (
+                        json_cmd["command"] == "startup"
+                        or json_cmd["command"] == "game/startup"
+                    ):
                         self.current_game = game
                     elif self.current_game != game:
-                        self.log_warning("Game name does not match the current game.")
+                        self.log_warning(
+                            "Game name does not match the current game.",
+                        )
                     elif self.current_game == "":
                         self.log_warning("No startup command received.")
 
                 # Check action result when waiting for it
-                if self.current_action_id is not None and json_cmd["command"] == "actions/force":
-                    self.log_warning("Received actions/force while waiting for action/result.")
+                if (
+                    self.current_action_id is not None
+                    and json_cmd["command"] == "actions/force"
+                ):
+                    self.log_warning(
+                        "Received actions/force while waiting for action/result.",
+                    )
 
-                self.log_system(f'Command received: {json_cmd["command"]}')
+                self.log_system(f"Command received: {json_cmd['command']}")
 
                 # Handle the command
                 match json_cmd["command"]:
@@ -236,10 +326,14 @@ class NeuroAPI:
                         self.on_startup(StartupCommand())
 
                         if json_cmd["command"] == "game/startup":
-                            self.log_warning('"game/startup" command is deprecated. Use "startup" instead.')
+                            self.log_warning(
+                                '"game/startup" command is deprecated. Use "startup" instead.',
+                            )
 
                     case "context":
-                        self.on_context(ContextCommand(data["message"], data["silent"]))
+                        self.on_context(
+                            ContextCommand(data["message"], data["silent"]),
+                        )
 
                     case "actions/register":
                         # Check the actions
@@ -247,34 +341,62 @@ class NeuroAPI:
                             # Check the schema
                             if "schema" in action and action["schema"] != {}:
                                 try:
-                                    jsonschema.Draft7Validator.check_schema(action["schema"])
+                                    jsonschema.Draft7Validator.check_schema(
+                                        action["schema"],
+                                    )
                                 except jsonschema.exceptions.SchemaError as e:
-                                    self.log_error(f'Invalid schema for action "{action["name"]}": {e}')
+                                    self.log_error(
+                                        f'Invalid schema for action "{action["name"]}": {e}',
+                                    )
                                     continue
 
-                                invalid_keys = self.check_invalid_keys_recursive(action["schema"])
+                                invalid_keys = (
+                                    self.check_invalid_keys_recursive(
+                                        action["schema"],
+                                    )
+                                )
 
                                 if len(invalid_keys) > 0:
-                                    self.log_warning(f'Disallowed keys in schema: {", ".join(invalid_keys)}')
+                                    self.log_warning(
+                                        f"Disallowed keys in schema: {', '.join(invalid_keys)}",
+                                    )
 
                             # Check the name
                             if not isinstance(action["name"], str):
-                                self.log_error(f'Action name is not a string: {action["name"]}')
+                                self.log_error(
+                                    f"Action name is not a string: {action['name']}",
+                                )
                                 continue
 
-                            if not all(c in ACTION_NAME_ALLOWED_CHARS for c in action["name"]):
-                                self.log_warning("Action name is not a lowercase string.")
+                            if not all(
+                                c in ACTION_NAME_ALLOWED_CHARS
+                                for c in action["name"]
+                            ):
+                                self.log_warning(
+                                    "Action name is not a lowercase string.",
+                                )
 
                             if action["name"] == "":
                                 self.log_warning("Action name is empty.")
 
-                        self.on_actions_register(ActionsRegisterCommand(data["actions"]))
+                        self.on_actions_register(
+                            ActionsRegisterCommand(data["actions"]),
+                        )
 
                     case "actions/unregister":
-                        self.on_actions_unregister(ActionsUnregisterCommand(data["action_names"]))
+                        self.on_actions_unregister(
+                            ActionsUnregisterCommand(data["action_names"]),
+                        )
 
                     case "actions/force":
-                        self.on_actions_force(ActionsForceCommand(data.get("state"), data["query"], data.get("ephemeral_context", False), data["action_names"]))
+                        self.on_actions_force(
+                            ActionsForceCommand(
+                                data.get("state"),
+                                data["query"],
+                                data.get("ephemeral_context", False),
+                                data["action_names"],
+                            ),
+                        )
 
                     case "action/result":
                         # Check if an action/result was expected
@@ -282,15 +404,24 @@ class NeuroAPI:
                             self.log_warning("Unexpected action/result.")
                         # Check if the action ID matches
                         elif self.current_action_id != data["id"]:
-                            self.log_warning(f'Received action ID "{data["id"]}" does not match the expected action ID "{self.current_action_id}".')
+                            self.log_warning(
+                                f'Received action ID "{data["id"]}" does not match the expected action ID "{self.current_action_id}".',
+                            )
 
-                        self.log_debug(f'Action ID: {data["id"]}')
+                        self.log_debug(f"Action ID: {data['id']}")
 
                         self.current_action_id = None
-                        self.on_action_result(ActionResultCommand(data["success"], data.get("message", None)))
+                        self.on_action_result(
+                            ActionResultCommand(
+                                data["success"],
+                                data.get("message", None),
+                            ),
+                        )
 
                     case "shutdown/ready":
-                        self.log_warning("This command is not officially supported.")
+                        self.log_warning(
+                            "This command is not officially supported.",
+                        )
                         self.on_shutdown_ready(ShutdownReadyCommand())
 
                     case _:
@@ -363,9 +494,11 @@ class NeuroAPI:
 
     def send_actions_reregister_all(self) -> bool:
         """Send an actions/reregister_all command."""
-        message = json.dumps({
-            "command": "actions/reregister_all",
-        })
+        message = json.dumps(
+            {
+                "command": "actions/reregister_all",
+            },
+        )
 
         if not self._submit_message(message):
             return False
@@ -377,12 +510,14 @@ class NeuroAPI:
 
     def send_shutdown_graceful(self, wants_shutdown: bool) -> bool:
         """Send a shutdown/graceful command."""
-        message = json.dumps({
-            "command": "shutdown/graceful",
-            "data": {
-                "wants_shutdown": wants_shutdown,
+        message = json.dumps(
+            {
+                "command": "shutdown/graceful",
+                "data": {
+                    "wants_shutdown": wants_shutdown,
+                },
             },
-        })
+        )
 
         if not self._submit_message(message):
             return False
@@ -394,9 +529,11 @@ class NeuroAPI:
 
     def send_shutdown_immediate(self) -> bool:
         """Send a shutdown/immediate command."""
-        message = json.dumps({
-            "command": "shutdown/immediate",
-        })
+        message = json.dumps(
+            {
+                "command": "shutdown/immediate",
+            },
+        )
 
         if not self._submit_message(message):
             return False
@@ -406,7 +543,10 @@ class NeuroAPI:
 
         return True
 
-    def check_invalid_keys_recursive(self, sub_schema: dict[str, Any]) -> list[str]:
+    def check_invalid_keys_recursive(
+        self,
+        sub_schema: dict[str, Any],
+    ) -> list[str]:
         """Recursively checks for invalid keys in the schema.
 
         Returns a list of invalid keys that were found.
@@ -423,9 +563,13 @@ class NeuroAPI:
             elif isinstance(value, list):
                 for item in value:
                     if isinstance(item, dict):
-                        invalid_keys.extend(self.check_invalid_keys_recursive(item))
+                        invalid_keys.extend(
+                            self.check_invalid_keys_recursive(item),
+                        )
             else:
-                self.log_error(f"Unhandled schema value type {type(value)!r} ({value!r})")
+                self.log_error(
+                    f"Unhandled schema value type {type(value)!r} ({value!r})",
+                )
 
         return invalid_keys
 
@@ -445,6 +589,7 @@ class ContextCommand(NamedTuple):
 
 class ActionsRegisterCommand:
     """`actions/register` command."""
+
     __slots__ = ("actions",)
 
     def __init__(self, actions: list[dict[str, Any]]) -> None:

--- a/src/neuro_api_tony/cli.py
+++ b/src/neuro_api_tony/cli.py
@@ -38,7 +38,20 @@ Options:
 
 def cli_run() -> None:
     """Command line interface entry point."""
-    options, _ = getopt(sys.argv[1:], "ha:l:p:v", ["help", "addr=", "address=", "log=", "log-level=", "port=", "update", "version"])
+    options, _ = getopt(
+        sys.argv[1:],
+        "ha:l:p:v",
+        [
+            "help",
+            "addr=",
+            "address=",
+            "log=",
+            "log-level=",
+            "port=",
+            "update",
+            "version",
+        ],
+    )
 
     address = "localhost"
     port = 8000
@@ -54,8 +67,16 @@ def cli_run() -> None:
                 address = value
 
             case "-l" | "--log" | "--log-level":
-                if value.upper() not in ["DEBUG", "INFO", "WARNING", "ERROR", "SYSTEM"]:
-                    print("Invalid log level. Must be one of: DEBUG, INFO, WARNING, ERROR, SYSTEM.")
+                if value.upper() not in [
+                    "DEBUG",
+                    "INFO",
+                    "WARNING",
+                    "ERROR",
+                    "SYSTEM",
+                ]:
+                    print(
+                        "Invalid log level. Must be one of: DEBUG, INFO, WARNING, ERROR, SYSTEM.",
+                    )
                     sys.exit(1)
                 log_level = value.upper()
 
@@ -63,7 +84,9 @@ def cli_run() -> None:
                 port = int(value)
 
             case "--update":
-                print("This option is deprecated. Please update the program using git or pip.")
+                print(
+                    "This option is deprecated. Please update the program using git or pip.",
+                )
 
                 sys.exit(1)
 
@@ -73,15 +96,21 @@ def cli_run() -> None:
 
     # Check if there are updates available
     try:
-        remote_version = requests.get(PYPI_API_URL, timeout=10).json()["info"]["version"]
+        remote_version = requests.get(PYPI_API_URL, timeout=10).json()["info"][
+            "version"
+        ]
 
         if semver.compare(remote_version, VERSION) > 0:
-            print(f'An update is available. ({VERSION} -> {remote_version})\n'
-                  f'Depending on your installation method, pull the latest changes from GitHub or\n'
-                  f'run "pip install --upgrade {PACKAGE_NAME}" to update.')
+            print(
+                f"An update is available. ({VERSION} -> {remote_version})\n"
+                f"Depending on your installation method, pull the latest changes from GitHub or\n"
+                f'run "pip install --upgrade {PACKAGE_NAME}" to update.',
+            )
 
     except ConnectionError:
-        print("Failed to check for updates. Please check your internet connection.")
+        print(
+            "Failed to check for updates. Please check your internet connection.",
+        )
 
     except Exception as exc:
         print("An error occurred while checking for updates:")

--- a/src/neuro_api_tony/cli.py
+++ b/src/neuro_api_tony/cli.py
@@ -96,9 +96,8 @@ def cli_run() -> None:
 
     # Check if there are updates available
     try:
-        remote_version = requests.get(PYPI_API_URL, timeout=10).json()["info"][
-            "version"
-        ]
+        response = requests.get(PYPI_API_URL, timeout=10).json()
+        remote_version = response["info"]["version"]
 
         if semver.compare(remote_version, VERSION) > 0:
             print(

--- a/src/neuro_api_tony/cli.py
+++ b/src/neuro_api_tony/cli.py
@@ -74,9 +74,7 @@ def cli_run() -> None:
                     "ERROR",
                     "SYSTEM",
                 ]:
-                    print(
-                        "Invalid log level. Must be one of: DEBUG, INFO, WARNING, ERROR, SYSTEM.",
-                    )
+                    print("Invalid log level. Must be one of: DEBUG, INFO, WARNING, ERROR, SYSTEM.")
                     sys.exit(1)
                 log_level = value.upper()
 
@@ -84,9 +82,7 @@ def cli_run() -> None:
                 port = int(value)
 
             case "--update":
-                print(
-                    "This option is deprecated. Please update the program using git or pip.",
-                )
+                print("This option is deprecated. Please update the program using git or pip.")
 
                 sys.exit(1)
 
@@ -107,9 +103,7 @@ def cli_run() -> None:
             )
 
     except ConnectionError:
-        print(
-            "Failed to check for updates. Please check your internet connection.",
-        )
+        print("Failed to check for updates. Please check your internet connection.")
 
     except Exception as exc:
         print("An error occurred while checking for updates:")

--- a/src/neuro_api_tony/controller.py
+++ b/src/neuro_api_tony/controller.py
@@ -105,9 +105,7 @@ class TonyController:
         for action in cmd.actions:
             # Check if an action with the same name already exists
             if self.model.has_action(action.name):
-                self.view.log_warning(
-                    f'Action "{action.name}" already exists. Ignoring.',
-                )
+                self.view.log_warning(f'Action "{action.name}" already exists. Ignoring.')
                 continue
 
             self.model.add_action(action)
@@ -143,11 +141,7 @@ class TonyController:
         if not all(self.model.has_action(name) for name in cmd.action_names):
             self.view.log_warning(
                 "actions/force with invalid actions received. Discarding.\nInvalid actions: "
-                + ", ".join(
-                    name
-                    for name in cmd.action_names
-                    if not self.model.has_action(name)
-                ),
+                + ", ".join(name for name in cmd.action_names if not self.model.has_action(name)),
             )
             self.active_actions_force = None
             return
@@ -156,14 +150,9 @@ class TonyController:
 
     def on_action_result(self, cmd: ActionResultCommand) -> None:
         """Handle the action/result command."""
-        self.view.log_system(
-            "Action result indicates "
-            + ("success" if cmd.success else "failure"),
-        )
+        self.view.log_system("Action result indicates " + ("success" if cmd.success else "failure"))
 
-        self.view.log_debug(
-            f"cmd.success: {cmd.success}, active_actions_force: {self.active_actions_force}",
-        )
+        self.view.log_debug(f"cmd.success: {cmd.success}, active_actions_force: {self.active_actions_force}")
 
         if not cmd.success and self.active_actions_force is not None:
             self.retry_actions_force(self.active_actions_force)
@@ -266,11 +255,7 @@ class TonyController:
 
         if self.view.controls.auto_send:
             self.view.log_system("Automatically sending random action.")
-            actions = [
-                action
-                for action in self.model.actions
-                if action.name in cmd.action_names
-            ]
+            actions = [action for action in self.model.actions if action.name in cmd.action_names]
             # S311 - Standard pseudo-random generators are not suitable for cryptographic purposes
             # Not using for cryptographic purposes so we should be fine
             action = random.choice(actions)  # noqa: S311
@@ -307,11 +292,7 @@ class TonyController:
         if not all(self.model.has_action(name) for name in cmd.action_names):
             self.view.log_warning(
                 "Actions have been unregistered before retrying the forced action. Retry aborted.\nInvalid actions: "
-                + ", ".join(
-                    name
-                    for name in cmd.action_names
-                    if not self.model.has_action(name)
-                ),
+                + ", ".join(name for name in cmd.action_names if not self.model.has_action(name)),
             )
             self.active_actions_force = None
             return

--- a/src/neuro_api_tony/controller.py
+++ b/src/neuro_api_tony/controller.py
@@ -60,6 +60,7 @@ class TonyController:
 
     def inject(self) -> None:
         """Inject methods into the view and API."""
+        # fmt: off
         self.api.on_startup = self.on_startup
         self.api.on_context = self.on_context
         self.api.on_actions_register = self.on_actions_register
@@ -81,18 +82,11 @@ class TonyController:
         self.view.on_delete_action = self.on_view_delete_action
         self.view.on_unlock = self.on_view_unlock
         self.view.on_clear_logs = self.on_view_clear_logs
-        self.view.on_send_actions_reregister_all = (
-            self.on_view_send_actions_reregister_all
-        )
-        self.view.on_send_shutdown_graceful = (
-            self.on_view_send_shutdown_graceful
-        )
-        self.view.on_send_shutdown_graceful_cancel = (
-            self.on_view_send_shutdown_graceful_cancel
-        )
-        self.view.on_send_shutdown_immediate = (
-            self.on_view_send_shutdown_immediate
-        )
+        self.view.on_send_actions_reregister_all = self.on_view_send_actions_reregister_all
+        self.view.on_send_shutdown_graceful = self.on_view_send_shutdown_graceful
+        self.view.on_send_shutdown_graceful_cancel = self.on_view_send_shutdown_graceful_cancel
+        self.view.on_send_shutdown_immediate = self.on_view_send_shutdown_immediate
+        # fmt: on
 
     def on_any_command(self, cmd: Any) -> None:
         """Handle any command received from the API."""

--- a/src/neuro_api_tony/model.py
+++ b/src/neuro_api_tony/model.py
@@ -7,6 +7,7 @@ from typing import Any, NamedTuple
 
 class NeuroAction(NamedTuple):
     """Neuro Action Object."""
+
     name: str
     description: str
     schema: dict[str, Any] | None
@@ -14,6 +15,7 @@ class NeuroAction(NamedTuple):
 
 class TonyModel:
     """Tony Model."""
+
     __slots__ = ("actions",)
 
     def __init__(self) -> None:

--- a/src/neuro_api_tony/view.py
+++ b/src/neuro_api_tony/view.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .model import NeuroAction, TonyModel
 
 
-#region Events
+# region Events
 
 EVTTYPE_ADD_ACTION = wx.NewEventType()
 EVT_ADD_ACTION = wx.PyEventBinder(EVTTYPE_ADD_ACTION, 1)
@@ -26,6 +26,7 @@ EVT_ADD_ACTION = wx.PyEventBinder(EVTTYPE_ADD_ACTION, 1)
 
 class AddActionEvent(wx.PyCommandEvent):  # type: ignore[misc]
     """An event for adding an action to the list."""
+
     __slots__ = ("action",)
 
     def __init__(self, id_: int, action: NeuroAction) -> None:
@@ -40,6 +41,7 @@ EVT_ACTION_RESULT = wx.PyEventBinder(EVTTYPE_ACTION_RESULT, 1)
 
 class ActionResultEvent(wx.PyCommandEvent):  # type: ignore[misc]
     """An event for an action result message."""
+
     __slots__ = ("message", "success")
 
     def __init__(self, id_: int, success: bool, message: str | None) -> None:
@@ -55,6 +57,7 @@ EVT_EXECUTE = wx.PyEventBinder(EVT_TYPE_EXECUTE, 1)
 
 class ExecuteEvent(wx.PyCommandEvent):  # type: ignore[misc]
     """An event for executing an action."""
+
     __slots__ = ("action",)
 
     def __init__(self, id_: int, action: NeuroAction) -> None:
@@ -62,28 +65,29 @@ class ExecuteEvent(wx.PyCommandEvent):  # type: ignore[misc]
         super().__init__(EVT_TYPE_EXECUTE, id_)
         self.action = action
 
-#endregion
 
-#region Constants
+# endregion
+
+# region Constants
 
 # Colors
-LOG_COLOR_DEFAULT                       = wx.Colour(  0,   0,   0)
-LOG_COLOR_TIMESTAMP                     = wx.Colour(  0, 128,   0)
-LOG_COLOR_DEBUG                         = wx.Colour(128, 128, 128)
-LOG_COLOR_INFO                          = wx.Colour(128, 192, 255)
-LOG_COLOR_WARNING                       = wx.Colour(255, 192,   0)
-LOG_COLOR_ERROR                         = wx.Colour(255,   0,   0)
-LOG_COLOR_CRITICAL                      = wx.Colour(192,   0,   0)
-LOG_COLOR_CONTEXT                       = LOG_COLOR_DEFAULT
-LOG_COLOR_CONTEXT_QUERY                 = wx.Colour(255, 128, 255)
-LOG_COLOR_CONTEXT_STATE                 = wx.Colour(128, 255, 128)
-LOG_COLOR_CONTEXT_SILENT                = wx.Colour(128, 128, 128)
-LOG_COLOR_CONTEXT_EPHEMERAL             = wx.Colour(128, 192, 255)
-LOG_COLOR_CONTEXT_ACTION                = LOG_COLOR_DEFAULT
-LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS = wx.Colour(  0, 128,   0)
-LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE = wx.Colour(255,   0,   0)
-LOG_COLOR_RAW_INCOMING              = wx.Colour(  0,   0, 255)
-LOG_COLOR_RAW_OUTGOING              = wx.Colour(255, 128, 192)
+LOG_COLOR_DEFAULT = wx.Colour(0, 0, 0)
+LOG_COLOR_TIMESTAMP = wx.Colour(0, 128, 0)
+LOG_COLOR_DEBUG = wx.Colour(128, 128, 128)
+LOG_COLOR_INFO = wx.Colour(128, 192, 255)
+LOG_COLOR_WARNING = wx.Colour(255, 192, 0)
+LOG_COLOR_ERROR = wx.Colour(255, 0, 0)
+LOG_COLOR_CRITICAL = wx.Colour(192, 0, 0)
+LOG_COLOR_CONTEXT = LOG_COLOR_DEFAULT
+LOG_COLOR_CONTEXT_QUERY = wx.Colour(255, 128, 255)
+LOG_COLOR_CONTEXT_STATE = wx.Colour(128, 255, 128)
+LOG_COLOR_CONTEXT_SILENT = wx.Colour(128, 128, 128)
+LOG_COLOR_CONTEXT_EPHEMERAL = wx.Colour(128, 192, 255)
+LOG_COLOR_CONTEXT_ACTION = LOG_COLOR_DEFAULT
+LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS = wx.Colour(0, 128, 0)
+LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE = wx.Colour(255, 0, 0)
+LOG_COLOR_RAW_INCOMING = wx.Colour(0, 0, 255)
+LOG_COLOR_RAW_OUTGOING = wx.Colour(255, 128, 192)
 
 UI_COLOR_ERROR = wx.Colour(255, 192, 192)
 
@@ -96,7 +100,8 @@ LOG_LEVELS = {
     "SYSTEM": 60,
 }
 
-#endregion
+# endregion
+
 
 class TonyView:
     """The view class for Tony."""
@@ -129,7 +134,9 @@ class TonyView:
         self.on_clear_logs: Callable[[], None] = lambda: None
         self.on_send_actions_reregister_all: Callable[[], None] = lambda: None
         self.on_send_shutdown_graceful: Callable[[], None] = lambda: None
-        self.on_send_shutdown_graceful_cancel: Callable[[], None] = lambda: None
+        self.on_send_shutdown_graceful_cancel: Callable[[], None] = (
+            lambda: None
+        )
         self.on_send_shutdown_immediate: Callable[[], None] = lambda: None
 
     def on_close(self, event: wx.CloseEvent) -> None:
@@ -151,27 +158,47 @@ class TonyView:
     def log_debug(self, message: str) -> None:
         """Log a debug message."""
         if self.controls.get_log_level() <= LOG_LEVELS["DEBUG"]:
-            self.frame.panel.log_notebook.log_panel.log(message, "Debug", LOG_COLOR_DEBUG)
+            self.frame.panel.log_notebook.log_panel.log(
+                message,
+                "Debug",
+                LOG_COLOR_DEBUG,
+            )
 
     def log_info(self, message: str) -> None:
         """Log an informational message."""
         if self.controls.get_log_level() <= LOG_LEVELS["INFO"]:
-            self.frame.panel.log_notebook.log_panel.log(message, "Info", LOG_COLOR_INFO)
+            self.frame.panel.log_notebook.log_panel.log(
+                message,
+                "Info",
+                LOG_COLOR_INFO,
+            )
 
     def log_warning(self, message: str) -> None:
         """Log a warning message."""
         if self.controls.get_log_level() <= LOG_LEVELS["WARNING"]:
-            self.frame.panel.log_notebook.log_panel.log(message, "Warning", LOG_COLOR_WARNING)
+            self.frame.panel.log_notebook.log_panel.log(
+                message,
+                "Warning",
+                LOG_COLOR_WARNING,
+            )
 
     def log_error(self, message: str) -> None:
         """Log an error message."""
         if self.controls.get_log_level() <= LOG_LEVELS["ERROR"]:
-            self.frame.panel.log_notebook.log_panel.log(message, "Error", LOG_COLOR_ERROR)
+            self.frame.panel.log_notebook.log_panel.log(
+                message,
+                "Error",
+                LOG_COLOR_ERROR,
+            )
 
     def log_critical(self, message: str) -> None:
         """Log a critical error message."""
         if self.controls.get_log_level() <= LOG_LEVELS["CRITICAL"]:
-            self.frame.panel.log_notebook.log_panel.log(message, "Critical", LOG_COLOR_CRITICAL)
+            self.frame.panel.log_notebook.log_panel.log(
+                message,
+                "Critical",
+                LOG_COLOR_CRITICAL,
+            )
 
     def log_context(self, message: str, silent: bool = False) -> None:
         """Log a context message."""
@@ -182,11 +209,19 @@ class TonyView:
             tags.append("silent")
             colors.append(LOG_COLOR_CONTEXT_SILENT)
 
-        self.frame.panel.log_notebook.context_log_panel.log(message, tags, colors)
+        self.frame.panel.log_notebook.context_log_panel.log(
+            message,
+            tags,
+            colors,
+        )
 
     def log_description(self, message: str) -> None:
         """Log an action description."""
-        self.frame.panel.log_notebook.context_log_panel.log(message, "Action", LOG_COLOR_CONTEXT)
+        self.frame.panel.log_notebook.context_log_panel.log(
+            message,
+            "Action",
+            LOG_COLOR_CONTEXT,
+        )
 
     def log_query(self, message: str, ephemeral: bool = False) -> None:
         """Log an actions/force query."""
@@ -197,7 +232,11 @@ class TonyView:
             tags.append("ephemeral")
             colors.append(LOG_COLOR_CONTEXT_EPHEMERAL)
 
-        self.frame.panel.log_notebook.context_log_panel.log(message, tags, colors)
+        self.frame.panel.log_notebook.context_log_panel.log(
+            message,
+            tags,
+            colors,
+        )
 
     def log_state(self, message: str, ephemeral: bool = False) -> None:
         """Log an actions/force state."""
@@ -208,11 +247,21 @@ class TonyView:
             tags.append("Ephemeral")
             colors.append(LOG_COLOR_CONTEXT_EPHEMERAL)
 
-        self.frame.panel.log_notebook.context_log_panel.log(message, tags, colors)
+        self.frame.panel.log_notebook.context_log_panel.log(
+            message,
+            tags,
+            colors,
+        )
 
     def log_action_result(self, success: bool, message: str) -> None:
         """Log an action result message."""
-        self.frame.panel.log_notebook.context_log_panel.log(message, "Result", LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS if success else LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE)
+        self.frame.panel.log_notebook.context_log_panel.log(
+            message,
+            "Result",
+            LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS
+            if success
+            else LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE,
+        )
 
     def log_raw(self, message: str, incoming: bool) -> None:
         """Log raw data."""
@@ -229,7 +278,11 @@ class TonyView:
 
     def show_action_dialog(self, action: NeuroAction) -> str | None:
         """Show a dialog for an action. Returns the JSON string the user entered if "Send" was clicked, otherwise None."""
-        self.action_dialog = ActionDialog(self.frame, action, self.controls.validate_schema)
+        self.action_dialog = ActionDialog(
+            self.frame,
+            action,
+            self.controls.validate_schema,
+        )
         result = self.action_dialog.ShowModal()
         text = self.action_dialog.text.GetValue()
         self.action_dialog.Destroy()
@@ -266,10 +319,29 @@ class TonyView:
         """Disable all action buttons."""
         self.frame.panel.action_list.execute_button.Disable()
 
-    def force_actions(self, state: str, query: str, ephemeral_context: bool, action_names: list[str], retry: bool = False) -> None:
+    def force_actions(
+        self,
+        state: str,
+        query: str,
+        ephemeral_context: bool,
+        action_names: list[str],
+        retry: bool = False,
+    ) -> None:
         """Show a dialog for forcing actions."""
-        actions = [action for action in self.model.actions if action.name in action_names]
-        actions_force_dialog = ActionsForceDialog(self.frame, self, state, query, ephemeral_context, actions, retry)
+        actions = [
+            action
+            for action in self.model.actions
+            if action.name in action_names
+        ]
+        actions_force_dialog = ActionsForceDialog(
+            self.frame,
+            self,
+            state,
+            query,
+            ephemeral_context,
+            actions,
+            retry,
+        )
         result = actions_force_dialog.ShowModal()
         actions_force_dialog.Destroy()
 
@@ -328,7 +400,11 @@ class MainPanel(wx.Panel):  # type: ignore[misc]
 class ActionList(wx.Panel):  # type: ignore[misc]
     """The list of actions."""
 
-    def __init__(self, parent: MainPanel | ActionsForceDialog, can_delete: bool) -> None:
+    def __init__(
+        self,
+        parent: MainPanel | ActionsForceDialog,
+        can_delete: bool,
+    ) -> None:
         """Initialize ActionList panel."""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
 
@@ -366,11 +442,21 @@ class ActionList(wx.Panel):  # type: ignore[misc]
         """Add an action panel to the list."""
         self.actions.append(action)
 
-        self.list.Append([action.name, action.description, "Yes" if action.schema is not None and action.schema != {} else "No"])
+        self.list.Append(
+            [
+                action.name,
+                action.description,
+                "Yes"
+                if action.schema is not None and action.schema != {}
+                else "No",
+            ],
+        )
 
     def remove_action_by_name(self, name: str) -> None:
         """Remove an action panel from the list."""
-        self.actions = [action for action in self.actions if action.name != name]
+        self.actions = [
+            action for action in self.actions if action.name != name
+        ]
 
         index = self.list.FindItem(-1, name)
         if index != -1:
@@ -398,7 +484,9 @@ class ActionList(wx.Panel):  # type: ignore[misc]
         sent = top.view.on_execute(action)
 
         if sent:
-            self.GetEventHandler().ProcessEvent(ExecuteEvent(self.GetId(), action))
+            self.GetEventHandler().ProcessEvent(
+                ExecuteEvent(self.GetId(), action),
+            )
         top.view.log_debug(f"Sent: {sent}")
 
     def on_delete(self, event: wx.CommandEvent) -> None:
@@ -432,7 +520,13 @@ class LogNotebook(wx.Notebook):  # type: ignore[misc]
 
         self.log_panel = LogPanel(self)
         self.context_log_panel = LogPanel(self)
-        self.raw_log_panel = LogPanel(self, text_ctrl_style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH | wx.HSCROLL)
+        self.raw_log_panel = LogPanel(
+            self,
+            text_ctrl_style=wx.TE_MULTILINE
+            | wx.TE_READONLY
+            | wx.TE_RICH
+            | wx.HSCROLL,
+        )
 
         self.AddPage(self.log_panel, "Log")
         self.AddPage(self.context_log_panel, "Context")
@@ -442,7 +536,11 @@ class LogNotebook(wx.Notebook):  # type: ignore[misc]
 class LogPanel(wx.Panel):  # type: ignore[misc]
     """The panel for logging messages."""
 
-    def __init__(self, parent: LogNotebook, text_ctrl_style: int = wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH) -> None:
+    def __init__(
+        self,
+        parent: LogNotebook,
+        text_ctrl_style: int = wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH,
+    ) -> None:
         """Initialize Log Panel."""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
 
@@ -473,7 +571,7 @@ class LogPanel(wx.Panel):  # type: ignore[misc]
 
         # Log timestamp
         self.text.SetDefaultStyle(wx.TextAttr(LOG_COLOR_TIMESTAMP))
-        self.text.AppendText(f'[{dt.now().strftime("%X")}] ')
+        self.text.AppendText(f"[{dt.now().strftime('%X')}] ")
 
         # Log tags
         for tag, tag_color in zip(tags, tag_colors, strict=True):
@@ -496,55 +594,131 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
 
         # Create controls
 
-        self.validate_schema_checkbox = wx.CheckBox(self, label="Validate JSON schema")
-        self.ignore_actions_force_checkbox = wx.CheckBox(self, label="Ignore forced actions")
-        self.auto_send_checkbox = wx.CheckBox(self, label="Automatically answer forced actions")
+        self.validate_schema_checkbox = wx.CheckBox(
+            self,
+            label="Validate JSON schema",
+        )
+        self.ignore_actions_force_checkbox = wx.CheckBox(
+            self,
+            label="Ignore forced actions",
+        )
+        self.auto_send_checkbox = wx.CheckBox(
+            self,
+            label="Automatically answer forced actions",
+        )
 
         latency_panel = wx.Panel(self)
         latency_text1 = wx.StaticText(latency_panel, label="L*tency:")
-        self.latency_input = wx.TextCtrl(latency_panel, value="0", size=(50, -1))
+        self.latency_input = wx.TextCtrl(
+            latency_panel,
+            value="0",
+            size=(50, -1),
+        )
         latency_text2 = wx.StaticText(latency_panel, label="ms")
 
         log_level_panel = wx.Panel(self)
         log_level_text = wx.StaticText(log_level_panel, label="Log level:")
-        self.log_level_choice = wx.Choice(log_level_panel, choices=[s.capitalize() for s in LOG_LEVELS])
+        self.log_level_choice = wx.Choice(
+            log_level_panel,
+            choices=[s.capitalize() for s in LOG_LEVELS],
+        )
 
         self.clear_logs_button = wx.Button(self, label="Clear logs")
-        self.send_actions_reregister_all_button = wx.Button(self, label="Clear all actions and request reregistration (experimental)")
-        self.send_shutdown_graceful_button = wx.Button(self, label="Request graceful shutdown (experimental)")
-        self.send_shutdown_graceful_cancel_button = wx.Button(self, label="Cancel graceful shutdown (experimental)")
-        self.send_shutdown_immediate_button = wx.Button(self, label="Request immediate shutdown (experimental)")
+        self.send_actions_reregister_all_button = wx.Button(
+            self,
+            label="Clear all actions and request reregistration (experimental)",
+        )
+        self.send_shutdown_graceful_button = wx.Button(
+            self,
+            label="Request graceful shutdown (experimental)",
+        )
+        self.send_shutdown_graceful_cancel_button = wx.Button(
+            self,
+            label="Cancel graceful shutdown (experimental)",
+        )
+        self.send_shutdown_immediate_button = wx.Button(
+            self,
+            label="Request immediate shutdown (experimental)",
+        )
 
         # Create sizers
 
         latency_panel_sizer = wx.BoxSizer(wx.HORIZONTAL)
         latency_panel_sizer.Add(latency_text1, 0, wx.ALL | wx.ALIGN_CENTER, 2)
-        latency_panel_sizer.Add(self.latency_input, 0, wx.ALL | wx.ALIGN_CENTER, 2)
+        latency_panel_sizer.Add(
+            self.latency_input,
+            0,
+            wx.ALL | wx.ALIGN_CENTER,
+            2,
+        )
         latency_panel_sizer.Add(latency_text2, 0, wx.ALL | wx.ALIGN_CENTER, 2)
         latency_panel.SetSizer(latency_panel_sizer)
 
         log_lever_panel_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        log_lever_panel_sizer.Add(log_level_text, 0, wx.ALL | wx.ALIGN_CENTER, 2)
-        log_lever_panel_sizer.Add(self.log_level_choice, 0, wx.ALL | wx.ALIGN_CENTER, 2)
+        log_lever_panel_sizer.Add(
+            log_level_text,
+            0,
+            wx.ALL | wx.ALIGN_CENTER,
+            2,
+        )
+        log_lever_panel_sizer.Add(
+            self.log_level_choice,
+            0,
+            wx.ALL | wx.ALIGN_CENTER,
+            2,
+        )
         log_level_panel.SetSizer(log_lever_panel_sizer)
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.sizer.Add(self.validate_schema_checkbox, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(self.ignore_actions_force_checkbox, 0, wx.EXPAND | wx.ALL, 2)
+        self.sizer.Add(
+            self.ignore_actions_force_checkbox,
+            0,
+            wx.EXPAND | wx.ALL,
+            2,
+        )
         self.sizer.Add(self.auto_send_checkbox, 0, wx.EXPAND | wx.ALL, 2)
         self.sizer.Add(latency_panel, 0, wx.EXPAND, 0)
         self.sizer.Add(log_level_panel, 0, wx.EXPAND, 0)
         self.sizer.Add(self.clear_logs_button, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(self.send_actions_reregister_all_button, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(self.send_shutdown_graceful_button, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(self.send_shutdown_graceful_cancel_button, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(self.send_shutdown_immediate_button, 0, wx.EXPAND | wx.ALL, 2)
+        self.sizer.Add(
+            self.send_actions_reregister_all_button,
+            0,
+            wx.EXPAND | wx.ALL,
+            2,
+        )
+        self.sizer.Add(
+            self.send_shutdown_graceful_button,
+            0,
+            wx.EXPAND | wx.ALL,
+            2,
+        )
+        self.sizer.Add(
+            self.send_shutdown_graceful_cancel_button,
+            0,
+            wx.EXPAND | wx.ALL,
+            2,
+        )
+        self.sizer.Add(
+            self.send_shutdown_immediate_button,
+            0,
+            wx.EXPAND | wx.ALL,
+            2,
+        )
         self.SetSizer(self.sizer)
 
         # Bind events
 
-        self.Bind(wx.EVT_CHECKBOX, self.on_validate_schema, self.validate_schema_checkbox)
-        self.Bind(wx.EVT_CHECKBOX, self.on_ignore_actions_force, self.ignore_actions_force_checkbox)
+        self.Bind(
+            wx.EVT_CHECKBOX,
+            self.on_validate_schema,
+            self.validate_schema_checkbox,
+        )
+        self.Bind(
+            wx.EVT_CHECKBOX,
+            self.on_ignore_actions_force,
+            self.ignore_actions_force_checkbox,
+        )
         self.Bind(wx.EVT_CHECKBOX, self.on_auto_send, self.auto_send_checkbox)
 
         self.Bind(wx.EVT_TEXT, self.on_latency, self.latency_input)
@@ -552,10 +726,26 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
         self.Bind(wx.EVT_CHOICE, self.on_log_level, self.log_level_choice)
 
         self.Bind(wx.EVT_BUTTON, self.on_clear_logs, self.clear_logs_button)
-        self.Bind(wx.EVT_BUTTON, self.on_send_actions_reregister_all, self.send_actions_reregister_all_button)
-        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_graceful, self.send_shutdown_graceful_button)
-        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_graceful_cancel, self.send_shutdown_graceful_cancel_button)
-        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_immediate, self.send_shutdown_immediate_button)
+        self.Bind(
+            wx.EVT_BUTTON,
+            self.on_send_actions_reregister_all,
+            self.send_actions_reregister_all_button,
+        )
+        self.Bind(
+            wx.EVT_BUTTON,
+            self.on_send_shutdown_graceful,
+            self.send_shutdown_graceful_button,
+        )
+        self.Bind(
+            wx.EVT_BUTTON,
+            self.on_send_shutdown_graceful_cancel,
+            self.send_shutdown_graceful_cancel_button,
+        )
+        self.Bind(
+            wx.EVT_BUTTON,
+            self.on_send_shutdown_immediate,
+            self.send_shutdown_immediate_button,
+        )
 
         # Set default values
 
@@ -563,7 +753,9 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
         self.ignore_actions_force_checkbox.SetValue(False)
         self.auto_send_checkbox.SetValue(False)
         # self.latency_input.SetValue('0')
-        self.log_level_choice.SetStringSelection(self.view.controls.get_log_level_str())
+        self.log_level_choice.SetStringSelection(
+            self.view.controls.get_log_level_str(),
+        )
 
         # Modify
 
@@ -603,7 +795,9 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
                 raise ValueError("Latency must not exceed 10000 ms.")
             self.view.controls.latency = latency
             self.latency_input.UnsetToolTip()
-            self.latency_input.SetBackgroundColour(wx.NullColour) # Default color
+            self.latency_input.SetBackgroundColour(
+                wx.NullColour,
+            )  # Default color
         except ValueError as exc:
             self.latency_input.SetToolTip(str(exc))
             self.latency_input.SetBackgroundColour(UI_COLOR_ERROR)
@@ -644,7 +838,12 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
 class ActionDialog(wx.Dialog):  # type: ignore[misc]
     """Action dialog."""
 
-    def __init__(self, parent: MainFrame, action: NeuroAction, do_validate: bool) -> None:
+    def __init__(
+        self,
+        parent: MainFrame,
+        action: NeuroAction,
+        do_validate: bool,
+    ) -> None:
         """Initialize Action Dialog."""
         super().__init__(parent, title=action.name)
 
@@ -694,9 +893,17 @@ class ActionDialog(wx.Dialog):  # type: ignore[misc]
 
         except Exception as exc:
             if isinstance(exc, jsonschema.ValidationError):
-                wx.MessageBox(f"JSON schema validation error: {exc}", "Error", wx.OK | wx.ICON_ERROR)
+                wx.MessageBox(
+                    f"JSON schema validation error: {exc}",
+                    "Error",
+                    wx.OK | wx.ICON_ERROR,
+                )
             elif isinstance(exc, json.JSONDecodeError):
-                wx.MessageBox(f"JSON decode error: {exc}", "Error", wx.OK | wx.ICON_ERROR)
+                wx.MessageBox(
+                    f"JSON decode error: {exc}",
+                    "Error",
+                    wx.OK | wx.ICON_ERROR,
+                )
             else:
                 raise exc
 
@@ -704,7 +911,11 @@ class ActionDialog(wx.Dialog):  # type: ignore[misc]
         """Handle show_schema command event."""
         event.Skip()
 
-        wx.MessageBox(json.dumps(self.action.schema, indent=2), "Schema", wx.OK | wx.ICON_INFORMATION)
+        wx.MessageBox(
+            json.dumps(self.action.schema, indent=2),
+            "Schema",
+            wx.OK | wx.ICON_INFORMATION,
+        )
 
     def on_cancel(self, event: wx.CommandEvent) -> None:
         """Handle cancel command event."""
@@ -728,7 +939,11 @@ class ActionsForceDialog(wx.Dialog):  # type: ignore[misc]
     ) -> None:
         """Initialize Forced Action Dialog."""
         title = "Forced Action" if not retry else "Retry Forced Action"
-        super().__init__(parent, title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+        super().__init__(
+            parent,
+            title=title,
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
 
         self.view = view
         self.state = state
@@ -738,7 +953,10 @@ class ActionsForceDialog(wx.Dialog):  # type: ignore[misc]
 
         self.state_label = wx.StaticText(self, label=f"State: {state}")
         self.query_label = wx.StaticText(self, label=f"Query: {query}")
-        self.ephemeral_context_label = wx.StaticText(self, label=f"Ephemeral Context: {ephemeral_context}")
+        self.ephemeral_context_label = wx.StaticText(
+            self,
+            label=f"Ephemeral Context: {ephemeral_context}",
+        )
         self.action_list = ActionList(self, False)
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)
@@ -760,6 +978,7 @@ class ActionsForceDialog(wx.Dialog):  # type: ignore[misc]
         event.Skip()
 
         self.EndModal(wx.ID_OK)
+
 
 class Controls:
     """The content of the control panel."""

--- a/src/neuro_api_tony/view.py
+++ b/src/neuro_api_tony/view.py
@@ -71,23 +71,25 @@ class ExecuteEvent(wx.PyCommandEvent):  # type: ignore[misc]
 # region Constants
 
 # Colors
-LOG_COLOR_DEFAULT = wx.Colour(0, 0, 0)
-LOG_COLOR_TIMESTAMP = wx.Colour(0, 128, 0)
-LOG_COLOR_DEBUG = wx.Colour(128, 128, 128)
-LOG_COLOR_INFO = wx.Colour(128, 192, 255)
-LOG_COLOR_WARNING = wx.Colour(255, 192, 0)
-LOG_COLOR_ERROR = wx.Colour(255, 0, 0)
-LOG_COLOR_CRITICAL = wx.Colour(192, 0, 0)
-LOG_COLOR_CONTEXT = LOG_COLOR_DEFAULT
-LOG_COLOR_CONTEXT_QUERY = wx.Colour(255, 128, 255)
-LOG_COLOR_CONTEXT_STATE = wx.Colour(128, 255, 128)
-LOG_COLOR_CONTEXT_SILENT = wx.Colour(128, 128, 128)
-LOG_COLOR_CONTEXT_EPHEMERAL = wx.Colour(128, 192, 255)
-LOG_COLOR_CONTEXT_ACTION = LOG_COLOR_DEFAULT
+# fmt: off
+LOG_COLOR_DEFAULT                       = wx.Colour(0, 0, 0)
+LOG_COLOR_TIMESTAMP                     = wx.Colour(0, 128, 0)
+LOG_COLOR_DEBUG                         = wx.Colour(128, 128, 128)
+LOG_COLOR_INFO                          = wx.Colour(128, 192, 255)
+LOG_COLOR_WARNING                       = wx.Colour(255, 192, 0)
+LOG_COLOR_ERROR                         = wx.Colour(255, 0, 0)
+LOG_COLOR_CRITICAL                      = wx.Colour(192, 0, 0)
+LOG_COLOR_CONTEXT                       = LOG_COLOR_DEFAULT
+LOG_COLOR_CONTEXT_QUERY                 = wx.Colour(255, 128, 255)
+LOG_COLOR_CONTEXT_STATE                 = wx.Colour(128, 255, 128)
+LOG_COLOR_CONTEXT_SILENT                = wx.Colour(128, 128, 128)
+LOG_COLOR_CONTEXT_EPHEMERAL             = wx.Colour(128, 192, 255)
+LOG_COLOR_CONTEXT_ACTION                = LOG_COLOR_DEFAULT
 LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS = wx.Colour(0, 128, 0)
 LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE = wx.Colour(255, 0, 0)
-LOG_COLOR_RAW_INCOMING = wx.Colour(0, 0, 255)
-LOG_COLOR_RAW_OUTGOING = wx.Colour(255, 128, 192)
+LOG_COLOR_RAW_INCOMING                  = wx.Colour(0, 0, 255)
+LOG_COLOR_RAW_OUTGOING                  = wx.Colour(255, 128, 192)
+# fmt: on
 
 UI_COLOR_ERROR = wx.Colour(255, 192, 192)
 

--- a/src/neuro_api_tony/view.py
+++ b/src/neuro_api_tony/view.py
@@ -130,16 +130,16 @@ class TonyView:
         self.action_dialog: ActionDialog | None = None
 
         # Dependency injection
+        # fmt: off
         self.on_execute: Callable[[NeuroAction], bool] = lambda action: False
         self.on_delete_action: Callable[[str], None] = lambda name: None
         self.on_unlock: Callable[[], None] = lambda: None
         self.on_clear_logs: Callable[[], None] = lambda: None
         self.on_send_actions_reregister_all: Callable[[], None] = lambda: None
         self.on_send_shutdown_graceful: Callable[[], None] = lambda: None
-        self.on_send_shutdown_graceful_cancel: Callable[[], None] = (
-            lambda: None
-        )
+        self.on_send_shutdown_graceful_cancel: Callable[[], None] = lambda: None
         self.on_send_shutdown_immediate: Callable[[], None] = lambda: None
+        # fmt: on
 
     def on_close(self, event: wx.CloseEvent) -> None:
         """Handle application close event."""

--- a/src/neuro_api_tony/view.py
+++ b/src/neuro_api_tony/view.py
@@ -260,9 +260,7 @@ class TonyView:
         self.frame.panel.log_notebook.context_log_panel.log(
             message,
             "Result",
-            LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS
-            if success
-            else LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE,
+            LOG_COLOR_CONTEXT_ACTION_RESULT_SUCCESS if success else LOG_COLOR_CONTEXT_ACTION_RESULT_FAILURE,
         )
 
     def log_raw(self, message: str, incoming: bool) -> None:
@@ -330,11 +328,7 @@ class TonyView:
         retry: bool = False,
     ) -> None:
         """Show a dialog for forcing actions."""
-        actions = [
-            action
-            for action in self.model.actions
-            if action.name in action_names
-        ]
+        actions = [action for action in self.model.actions if action.name in action_names]
         actions_force_dialog = ActionsForceDialog(
             self.frame,
             self,
@@ -448,17 +442,13 @@ class ActionList(wx.Panel):  # type: ignore[misc]
             [
                 action.name,
                 action.description,
-                "Yes"
-                if action.schema is not None and action.schema != {}
-                else "No",
+                "Yes" if action.schema is not None and action.schema != {} else "No",
             ],
         )
 
     def remove_action_by_name(self, name: str) -> None:
         """Remove an action panel from the list."""
-        self.actions = [
-            action for action in self.actions if action.name != name
-        ]
+        self.actions = [action for action in self.actions if action.name != name]
 
         index = self.list.FindItem(-1, name)
         if index != -1:
@@ -486,9 +476,7 @@ class ActionList(wx.Panel):  # type: ignore[misc]
         sent = top.view.on_execute(action)
 
         if sent:
-            self.GetEventHandler().ProcessEvent(
-                ExecuteEvent(self.GetId(), action),
-            )
+            self.GetEventHandler().ProcessEvent(ExecuteEvent(self.GetId(), action))
         top.view.log_debug(f"Sent: {sent}")
 
     def on_delete(self, event: wx.CommandEvent) -> None:
@@ -524,10 +512,7 @@ class LogNotebook(wx.Notebook):  # type: ignore[misc]
         self.context_log_panel = LogPanel(self)
         self.raw_log_panel = LogPanel(
             self,
-            text_ctrl_style=wx.TE_MULTILINE
-            | wx.TE_READONLY
-            | wx.TE_RICH
-            | wx.HSCROLL,
+            text_ctrl_style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH | wx.HSCROLL,
         )
 
         self.AddPage(self.log_panel, "Log")
@@ -596,131 +581,55 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
 
         # Create controls
 
-        self.validate_schema_checkbox = wx.CheckBox(
-            self,
-            label="Validate JSON schema",
-        )
-        self.ignore_actions_force_checkbox = wx.CheckBox(
-            self,
-            label="Ignore forced actions",
-        )
-        self.auto_send_checkbox = wx.CheckBox(
-            self,
-            label="Automatically answer forced actions",
-        )
+        self.validate_schema_checkbox = wx.CheckBox(self, label="Validate JSON schema")
+        self.ignore_actions_force_checkbox = wx.CheckBox(self, label="Ignore forced actions")
+        self.auto_send_checkbox = wx.CheckBox(self, label="Automatically answer forced actions")
 
         latency_panel = wx.Panel(self)
         latency_text1 = wx.StaticText(latency_panel, label="L*tency:")
-        self.latency_input = wx.TextCtrl(
-            latency_panel,
-            value="0",
-            size=(50, -1),
-        )
+        self.latency_input = wx.TextCtrl(latency_panel, value="0", size=(50, -1))
         latency_text2 = wx.StaticText(latency_panel, label="ms")
 
         log_level_panel = wx.Panel(self)
         log_level_text = wx.StaticText(log_level_panel, label="Log level:")
-        self.log_level_choice = wx.Choice(
-            log_level_panel,
-            choices=[s.capitalize() for s in LOG_LEVELS],
-        )
+        self.log_level_choice = wx.Choice(log_level_panel, choices=[s.capitalize() for s in LOG_LEVELS])
 
         self.clear_logs_button = wx.Button(self, label="Clear logs")
-        self.send_actions_reregister_all_button = wx.Button(
-            self,
-            label="Clear all actions and request reregistration (experimental)",
-        )
-        self.send_shutdown_graceful_button = wx.Button(
-            self,
-            label="Request graceful shutdown (experimental)",
-        )
-        self.send_shutdown_graceful_cancel_button = wx.Button(
-            self,
-            label="Cancel graceful shutdown (experimental)",
-        )
-        self.send_shutdown_immediate_button = wx.Button(
-            self,
-            label="Request immediate shutdown (experimental)",
-        )
+        self.send_actions_reregister_all_button = wx.Button(self, label="Clear all actions and request reregistration (experimental)")  # fmt: skip
+        self.send_shutdown_graceful_button = wx.Button(self, label="Request graceful shutdown (experimental)")
+        self.send_shutdown_graceful_cancel_button = wx.Button(self, label="Cancel graceful shutdown (experimental)")
+        self.send_shutdown_immediate_button = wx.Button(self, label="Request immediate shutdown (experimental)")
 
         # Create sizers
 
         latency_panel_sizer = wx.BoxSizer(wx.HORIZONTAL)
         latency_panel_sizer.Add(latency_text1, 0, wx.ALL | wx.ALIGN_CENTER, 2)
-        latency_panel_sizer.Add(
-            self.latency_input,
-            0,
-            wx.ALL | wx.ALIGN_CENTER,
-            2,
-        )
+        latency_panel_sizer.Add(self.latency_input, 0, wx.ALL | wx.ALIGN_CENTER, 2)
         latency_panel_sizer.Add(latency_text2, 0, wx.ALL | wx.ALIGN_CENTER, 2)
         latency_panel.SetSizer(latency_panel_sizer)
 
         log_lever_panel_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        log_lever_panel_sizer.Add(
-            log_level_text,
-            0,
-            wx.ALL | wx.ALIGN_CENTER,
-            2,
-        )
-        log_lever_panel_sizer.Add(
-            self.log_level_choice,
-            0,
-            wx.ALL | wx.ALIGN_CENTER,
-            2,
-        )
+        log_lever_panel_sizer.Add(log_level_text, 0, wx.ALL | wx.ALIGN_CENTER, 2)
+        log_lever_panel_sizer.Add(self.log_level_choice, 0, wx.ALL | wx.ALIGN_CENTER, 2)
         log_level_panel.SetSizer(log_lever_panel_sizer)
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.sizer.Add(self.validate_schema_checkbox, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(
-            self.ignore_actions_force_checkbox,
-            0,
-            wx.EXPAND | wx.ALL,
-            2,
-        )
+        self.sizer.Add(self.ignore_actions_force_checkbox, 0, wx.EXPAND | wx.ALL, 2)
         self.sizer.Add(self.auto_send_checkbox, 0, wx.EXPAND | wx.ALL, 2)
         self.sizer.Add(latency_panel, 0, wx.EXPAND, 0)
         self.sizer.Add(log_level_panel, 0, wx.EXPAND, 0)
         self.sizer.Add(self.clear_logs_button, 0, wx.EXPAND | wx.ALL, 2)
-        self.sizer.Add(
-            self.send_actions_reregister_all_button,
-            0,
-            wx.EXPAND | wx.ALL,
-            2,
-        )
-        self.sizer.Add(
-            self.send_shutdown_graceful_button,
-            0,
-            wx.EXPAND | wx.ALL,
-            2,
-        )
-        self.sizer.Add(
-            self.send_shutdown_graceful_cancel_button,
-            0,
-            wx.EXPAND | wx.ALL,
-            2,
-        )
-        self.sizer.Add(
-            self.send_shutdown_immediate_button,
-            0,
-            wx.EXPAND | wx.ALL,
-            2,
-        )
+        self.sizer.Add(self.send_actions_reregister_all_button, 0, wx.EXPAND | wx.ALL, 2)
+        self.sizer.Add(self.send_shutdown_graceful_button, 0, wx.EXPAND | wx.ALL, 2)
+        self.sizer.Add(self.send_shutdown_graceful_cancel_button, 0, wx.EXPAND | wx.ALL, 2)
+        self.sizer.Add(self.send_shutdown_immediate_button, 0, wx.EXPAND | wx.ALL, 2)
         self.SetSizer(self.sizer)
 
         # Bind events
 
-        self.Bind(
-            wx.EVT_CHECKBOX,
-            self.on_validate_schema,
-            self.validate_schema_checkbox,
-        )
-        self.Bind(
-            wx.EVT_CHECKBOX,
-            self.on_ignore_actions_force,
-            self.ignore_actions_force_checkbox,
-        )
+        self.Bind(wx.EVT_CHECKBOX, self.on_validate_schema, self.validate_schema_checkbox)
+        self.Bind(wx.EVT_CHECKBOX, self.on_ignore_actions_force, self.ignore_actions_force_checkbox)
         self.Bind(wx.EVT_CHECKBOX, self.on_auto_send, self.auto_send_checkbox)
 
         self.Bind(wx.EVT_TEXT, self.on_latency, self.latency_input)
@@ -728,26 +637,10 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
         self.Bind(wx.EVT_CHOICE, self.on_log_level, self.log_level_choice)
 
         self.Bind(wx.EVT_BUTTON, self.on_clear_logs, self.clear_logs_button)
-        self.Bind(
-            wx.EVT_BUTTON,
-            self.on_send_actions_reregister_all,
-            self.send_actions_reregister_all_button,
-        )
-        self.Bind(
-            wx.EVT_BUTTON,
-            self.on_send_shutdown_graceful,
-            self.send_shutdown_graceful_button,
-        )
-        self.Bind(
-            wx.EVT_BUTTON,
-            self.on_send_shutdown_graceful_cancel,
-            self.send_shutdown_graceful_cancel_button,
-        )
-        self.Bind(
-            wx.EVT_BUTTON,
-            self.on_send_shutdown_immediate,
-            self.send_shutdown_immediate_button,
-        )
+        self.Bind(wx.EVT_BUTTON, self.on_send_actions_reregister_all, self.send_actions_reregister_all_button)
+        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_graceful, self.send_shutdown_graceful_button)
+        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_graceful_cancel, self.send_shutdown_graceful_cancel_button)
+        self.Bind(wx.EVT_BUTTON, self.on_send_shutdown_immediate, self.send_shutdown_immediate_button)
 
         # Set default values
 
@@ -755,9 +648,7 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
         self.ignore_actions_force_checkbox.SetValue(False)
         self.auto_send_checkbox.SetValue(False)
         # self.latency_input.SetValue('0')
-        self.log_level_choice.SetStringSelection(
-            self.view.controls.get_log_level_str(),
-        )
+        self.log_level_choice.SetStringSelection(self.view.controls.get_log_level_str())
 
         # Modify
 
@@ -797,9 +688,7 @@ class ControlPanel(wx.Panel):  # type: ignore[misc]
                 raise ValueError("Latency must not exceed 10000 ms.")
             self.view.controls.latency = latency
             self.latency_input.UnsetToolTip()
-            self.latency_input.SetBackgroundColour(
-                wx.NullColour,
-            )  # Default color
+            self.latency_input.SetBackgroundColour(wx.NullColour)  # Default color
         except ValueError as exc:
             self.latency_input.SetToolTip(str(exc))
             self.latency_input.SetBackgroundColour(UI_COLOR_ERROR)
@@ -955,10 +844,7 @@ class ActionsForceDialog(wx.Dialog):  # type: ignore[misc]
 
         self.state_label = wx.StaticText(self, label=f"State: {state}")
         self.query_label = wx.StaticText(self, label=f"Query: {query}")
-        self.ephemeral_context_label = wx.StaticText(
-            self,
-            label=f"Ephemeral Context: {ephemeral_context}",
-        )
+        self.ephemeral_context_label = wx.StaticText(self, label=f"Ephemeral Context: {ephemeral_context}")
         self.action_list = ActionList(self, False)
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,7 +154,10 @@ def test_send_action_with_data(api: NeuroAPI) -> None:
     assert api.send_action("123", "test_action", "data field")
 
     assert api.current_action_id == "123"
-    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": "data field"}}'
+    assert (
+        receive.receive_nowait()
+        == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": "data field"}}'
+    )
 
 
 def test_send_actions_reregister_all(api: NeuroAPI) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,10 +144,7 @@ def test_send_action(api: NeuroAPI) -> None:
     assert api.send_action("123", "test_action", None)
 
     assert api.current_action_id == "123"
-    assert (
-        receive.receive_nowait()
-        == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": null}}'
-    )
+    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": null}}'  # fmt: skip
 
 
 def test_send_actions_reregister_all(api: NeuroAPI) -> None:
@@ -170,10 +167,7 @@ def test_send_shutdown_graceful(api: NeuroAPI) -> None:
     api.message_send_channel = send
     assert api.send_shutdown_graceful(True)
 
-    assert (
-        receive.receive_nowait()
-        == '{"command": "shutdown/graceful", "data": {"wants_shutdown": true}}'
-    )
+    assert receive.receive_nowait() == '{"command": "shutdown/graceful", "data": {"wants_shutdown": true}}'
 
 
 def test_send_shutdown_graceful_not_connected(api: NeuroAPI) -> None:
@@ -233,9 +227,7 @@ def test_check_invalid_keys_recursive_unhandled(api: NeuroAPI) -> None:
 
     invalid = api.check_invalid_keys_recursive(schema)
     assert invalid == ["writeOnly"]
-    api.log_error.assert_called_once_with(
-        "Unhandled schema value type <class 'set'> (set())",
-    )
+    api.log_error.assert_called_once_with("Unhandled schema value type <class 'set'> (set())")
 
 
 def test_actions_register_command() -> None:
@@ -345,10 +337,7 @@ async def test_handle_consumer_invalid_json(api: NeuroAPI) -> None:
     ) -> None:
         nonlocal had_json_error
         exc = multi_exc.args[1][0]
-        assert (
-            exc.args[0]
-            == "Expecting ',' delimiter: line 1 column 43 (char 42)"
-        )
+        assert exc.args[0] == "Expecting ',' delimiter: line 1 column 43 (char 42)"
         had_json_error = True
 
     with catch(
@@ -381,9 +370,7 @@ async def test_handle_producer(api: NeuroAPI) -> None:
     mock_websocket.send_message = AsyncMock(return_value=None)
     api.message_send_channel = send
 
-    send.send_nowait(
-        '{"command": "action", "data": {"id": "123", "name": "test_action"}}',
-    )
+    send.send_nowait('{"command": "action", "data": {"id": "123", "name": "test_action"}}')
 
     async with trio.open_nursery() as nursery:
         nursery.start_soon(api._handle_producer, mock_websocket, receive)
@@ -436,9 +423,7 @@ async def test_handle_consumer_action_result(api: NeuroAPI) -> None:
     mock_websocket.get_message = receive.receive
     api.message_send_channel = send
 
-    await send.send(
-        '{"command": "action/result", "data": {"id": "123", "success": true}}',
-    )
+    await send.send('{"command": "action/result", "data": {"id": "123", "success": true}}')
 
     async with trio.open_nursery() as nursery:
         cancel_scope = trio.CancelScope()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ def api() -> NeuroAPI:
 @pytest.fixture(autouse=True)
 def print_exception_to_raise() -> Generator[None, None, None]:
     """Make traceback.print_exception raise exception instead of printing it."""
+
     def raise_(exc: BaseException) -> None:
         raise exc from None
 
@@ -58,6 +59,7 @@ def test_start(api: NeuroAPI) -> None:
 def test_run_start_stop(api: NeuroAPI) -> None:
     """Test starting and stopping the WebSocket server."""
     tasks: list[Callable[[], None]] = []
+
     def run_sync_soon_threadsafe(func: Callable[[], None]) -> None:
         tasks.append(func)
 
@@ -106,6 +108,7 @@ def test_run_start_stop(api: NeuroAPI) -> None:
 
 def test_run_start_failure(api: NeuroAPI) -> None:
     """Test that async_library_running is handled even if guest run start fails."""
+
     def start_guest_run(*args: Any, **kwargs: Any) -> None:
         raise ValueError("jerald")
 
@@ -141,7 +144,10 @@ def test_send_action(api: NeuroAPI) -> None:
     assert api.send_action("123", "test_action", None)
 
     assert api.current_action_id == "123"
-    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": null}}'
+    assert (
+        receive.receive_nowait()
+        == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": null}}'
+    )
 
 
 def test_send_actions_reregister_all(api: NeuroAPI) -> None:
@@ -164,7 +170,10 @@ def test_send_shutdown_graceful(api: NeuroAPI) -> None:
     api.message_send_channel = send
     assert api.send_shutdown_graceful(True)
 
-    assert receive.receive_nowait() == '{"command": "shutdown/graceful", "data": {"wants_shutdown": true}}'
+    assert (
+        receive.receive_nowait()
+        == '{"command": "shutdown/graceful", "data": {"wants_shutdown": true}}'
+    )
 
 
 def test_send_shutdown_graceful_not_connected(api: NeuroAPI) -> None:
@@ -179,6 +188,7 @@ def test_send_shutdown_immediate(api: NeuroAPI) -> None:
     assert api.send_shutdown_immediate()
 
     assert receive.receive_nowait() == '{"command": "shutdown/immediate"}'
+
 
 def test_send_shutdown_immediate_not_connected(api: NeuroAPI) -> None:
     """Test sending immediate shutdown command but not connected."""
@@ -227,6 +237,7 @@ def test_check_invalid_keys_recursive_unhandled(api: NeuroAPI) -> None:
         "Unhandled schema value type <class 'set'> (set())",
     )
 
+
 def test_actions_register_command() -> None:
     actions: list[dict[str, Any]] = [
         {
@@ -251,15 +262,19 @@ def test_actions_register_command() -> None:
 async def test_handle_websocket_request_accept(api: NeuroAPI) -> None:
     """Test handling a WebSocket connection request."""
     send, receive = trio.open_memory_channel[str](1)
+
     class Websocket:
         get_message = receive.receive
         send_message = send.send
+
     class Request:
         async def accept(self) -> AbstractAsyncContextManager[Websocket]:
             @asynccontextmanager
             async def manager() -> AsyncGenerator[Websocket, None]:
                 yield Websocket()
+
             return manager()
+
     request = Request()
 
     async with trio.open_nursery() as nursery:
@@ -283,7 +298,11 @@ async def test_handle_client_connection(api: NeuroAPI) -> None:
     await send.send('{"command": "startup", "game": "test_game"}')
 
     async with trio.open_nursery() as nursery:
-        nursery.start_soon(api._handle_client_connection, mock_websocket, receive)
+        nursery.start_soon(
+            api._handle_client_connection,
+            mock_websocket,
+            receive,
+        )
         await trio.sleep(0.05)
         nursery.cancel_scope.cancel()
 
@@ -320,19 +339,30 @@ async def test_handle_consumer_invalid_json(api: NeuroAPI) -> None:
     await send.send('{"command": "startup", "game": "test_game"')
 
     had_json_error = False
-    def handle_json_error(multi_exc: BaseExceptionGroup[JSONDecodeError]) -> None:
+
+    def handle_json_error(
+        multi_exc: BaseExceptionGroup[JSONDecodeError],
+    ) -> None:
         nonlocal had_json_error
         exc = multi_exc.args[1][0]
-        assert exc.args[0] == "Expecting ',' delimiter: line 1 column 43 (char 42)"
+        assert (
+            exc.args[0]
+            == "Expecting ',' delimiter: line 1 column 43 (char 42)"
+        )
         had_json_error = True
 
-
-    with catch({
-        JSONDecodeError: handle_json_error,
-    }):
+    with catch(
+        {
+            JSONDecodeError: handle_json_error,
+        },
+    ):
         async with trio.open_nursery() as nursery:
             cancel_scope = trio.CancelScope()
-            nursery.start_soon(api._handle_consumer, mock_websocket, cancel_scope)
+            nursery.start_soon(
+                api._handle_consumer,
+                mock_websocket,
+                cancel_scope,
+            )
             await trio.sleep(0.05)
             cancel_scope.cancel()
             nursery.cancel_scope.cancel()
@@ -351,14 +381,18 @@ async def test_handle_producer(api: NeuroAPI) -> None:
     mock_websocket.send_message = AsyncMock(return_value=None)
     api.message_send_channel = send
 
-    send.send_nowait('{"command": "action", "data": {"id": "123", "name": "test_action"}}')
+    send.send_nowait(
+        '{"command": "action", "data": {"id": "123", "name": "test_action"}}',
+    )
 
     async with trio.open_nursery() as nursery:
         nursery.start_soon(api._handle_producer, mock_websocket, receive)
         await trio.sleep(0.05)
         nursery.cancel_scope.cancel()
 
-    mock_websocket.send_message.assert_called_once_with('{"command": "action", "data": {"id": "123", "name": "test_action"}}')
+    mock_websocket.send_message.assert_called_once_with(
+        '{"command": "action", "data": {"id": "123", "name": "test_action"}}',
+    )
 
 
 @pytest.mark.trio
@@ -402,7 +436,9 @@ async def test_handle_consumer_action_result(api: NeuroAPI) -> None:
     mock_websocket.get_message = receive.receive
     api.message_send_channel = send
 
-    await send.send('{"command": "action/result", "data": {"id": "123", "success": true}}')
+    await send.send(
+        '{"command": "action/result", "data": {"id": "123", "success": true}}',
+    )
 
     async with trio.open_nursery() as nursery:
         cancel_scope = trio.CancelScope()


### PR DESCRIPTION
In this pull request, we format the code using `ruff format`

Currently, Ruff's rule `COM812` is still enabled, meaning in some cases formatting and linting runs may need multiple runs in succession to stop making changes, and ruff does recommend disabling it, but feedback is wanted.