### PR TITLE
Fix sending action without data

### DIFF
--- a/src/neuro_api_tony/api.py
+++ b/src/neuro_api_tony/api.py
@@ -341,13 +341,15 @@ class NeuroAPI:
 
     def send_action(self, id_: str, name: str, data: str | None) -> bool:
         """Send an action command. Return True if actually sent."""
+        payload = {
+            "id": id_,
+            "name": name,
+        }
+        if data is not None:
+            payload["data"] = data
         obj = {
             "command": "action",
-            "data": {
-                "id": id_,
-                "name": name,
-                "data": data,
-            },
+            "data": payload,
         }
 
         message = json.dumps(obj)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,17 @@ def test_send_action(api: NeuroAPI) -> None:
     assert api.send_action("123", "test_action", None)
 
     assert api.current_action_id == "123"
-    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": null}}'
+    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action"}}'
+
+
+def test_send_action_with_data(api: NeuroAPI) -> None:
+    """Test sending an action command."""
+    send, receive = trio.open_memory_channel[str](1)
+    api.message_send_channel = send
+    assert api.send_action("123", "test_action", "data field")
+
+    assert api.current_action_id == "123"
+    assert receive.receive_nowait() == '{"command": "action", "data": {"id": "123", "name": "test_action", "data": "data field"}}'
 
 
 def test_send_actions_reregister_all(api: NeuroAPI) -> None:


### PR DESCRIPTION
I introduced this bug by accident, API specifications say data should be a string or not exist, never `null`. This pull request fixes the case where `data` is none.