### PR TITLE
Ignore zizmor hash pinnning

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # TODO: use the default policies
+        "*": any


### PR DESCRIPTION
In this pull request, we tell zizmor to ignore forcing github actions versions to be pinned with a hash, which while this does mean duplicate versions with the same identifier could be pushed and run code that wasn't intended, this makes it more work to keep github actions tools up to date.

This should be merged before #22 is merged.