### PR TITLE
Fix `ClientMenu` selector

### DIFF
--- a/src/neuro_api_tony/view.py
+++ b/src/neuro_api_tony/view.py
@@ -1726,8 +1726,8 @@ class ClientMenu(wx.Menu):  # type: ignore[misc]
                 connected_client_ids.add(action.client_id)
 
         all_clients_item = wx.MenuItem(self, wx.ID_ANY, "All Clients")
-        all_clients_item.Enable(clients != [])
         self.Append(all_clients_item)
+        all_clients_item.Enable(bool(clients))
         if clients:
             self.AppendSeparator()
 


### PR DESCRIPTION
In this pull request, we fix this exception I kept encountering regardless of if a client was connected or not:
```console
Traceback (most recent call last):
  File "/home/<username>/Desktop/Github-Clones/neuro-api-tony/src/neuro_api_tony/view.py", line 1131, in on_send_actions_reregister_all
    menu = ClientMenu(self.view, self.view.on_send_actions_reregister_all)
  File "/home/<username>/Desktop/Github-Clones/neuro-api-tony/src/neuro_api_tony/view.py", line 1737, in __init__
    all_clients_item.Enable(clients != [])
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
wx._core.wxAssertionError: C++ assertion ""m_menuItem"" failed at /tmp/pip-req-build-fmro0ejn/ext/wxWidgets/src/gtk/menu.cpp(803) in Enable(): invalid menu item
```

Turns out for `Enable` to work, widget needs to be bound to a parent first.